### PR TITLE
Pin test deps and document test_api.py in testing README

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -2,9 +2,12 @@
 
 This directory contains scripts for testing the auction site API.
 
-## auctions-curl / auctions-curl.py
+- **`auctions-curl.py`** — manual curl-style requests against a running API.
+- **`test_api.py`** — automated pytest API conformance suite (see below).
 
-Curl equivalents of the Postman 'AuctionSite' v2 requests. Available in both bash and Python versions.
+## auctions-curl.py
+
+Curl equivalents of the Postman 'AuctionSite' v2 requests.
 
 ### Commands
 
@@ -20,30 +23,6 @@ Curl equivalents of the Postman 'AuctionSite' v2 requests. Available in both bas
 - `BUYER` - JWT payload for buyer authentication (default provided)
 
 ### Usage
-
-#### Bash version
-
-```bash
-# Show help
-./auctions-curl help
-
-# Create an auction
-./auctions-curl create-auction
-
-# Place a bid (auction_id=1, amount=20)
-./auctions-curl place-bid 1 20
-
-# Show a specific auction
-./auctions-curl show-auction 1
-
-# List all auctions
-./auctions-curl list-auctions
-
-# With custom environment variables
-URL=http://localhost:8080 ./auctions-curl create-auction
-```
-
-#### Python version
 
 ```bash
 # Show help
@@ -65,24 +44,61 @@ python3 auctions-curl.py list-auctions
 URL=http://localhost:8080 python3 auctions-curl.py create-auction
 ```
 
-**Requirements for Python version:**
+**Setup (installs `requests` and `pytest`):**
 ```bash
 python3 -m venv testing
 source testing/bin/activate
-python3 -m pip install requests
+python3 -m pip install -r requirements.txt
 ```
 
-### Examples
+This installs both `requests` (for `auctions-curl.py`) and `pytest` (for
+`test_api.py`). To run the tests:
+
+```bash
+python3 -m pytest test_api.py
+```
+
+## test_api.py
+
+Automated API conformance tests (pytest), ported from `haskell-api/test/ApiSpec.hs`.
+They exercise the HTTP surface shared by all auction API implementations: adding
+auctions, placing bids, auth, and auction-timing rules.
+
+These tests require **pytest** and **requests** — both are pinned in
+`requirements.txt` (see setup above).
+
+### Running
+
+```bash
+# Activate the venv first
+source testing/bin/activate
+
+# Run all tests (verbose)
+python3 -m pytest test_api.py -v
+
+# Run against a different URL (default: http://127.0.0.1:8080)
+URL=http://localhost:9000 python3 -m pytest test_api.py -v
+```
+
+A target API must be running and reachable at `URL`.
+
+### Environment Variables
+
+- `URL` - API base URL (default: `http://127.0.0.1:8080`)
+- `SELLER` / `BUYER` - JWT payloads for authentication (defaults provided)
+- `REQUEST_TIMEOUT` - per-request timeout in seconds (default: `10`)
+
+## Examples
 
 ```bash
 # Create an auction with custom URL
-URL=http://localhost:8080 ./auctions-curl create-auction
+URL=http://localhost:8080 python3 auctions-curl.py create-auction
 
 # Place multiple bids
-./auctions-curl place-bid 1 15
-./auctions-curl place-bid 1 25
-./auctions-curl place-bid 1 30
+python3 auctions-curl.py place-bid 1 15
+python3 auctions-curl.py place-bid 1 25
+python3 auctions-curl.py place-bid 1 30
 
 # Check auction status
-./auctions-curl show-auction 1
+python3 auctions-curl.py show-auction 1
 ```

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -1,0 +1,2 @@
+pytest==9.0.2
+requests==2.32.5


### PR DESCRIPTION
Add requirements.txt pinning pytest and requests so the testing venv is reproducible (pytest was installed ad-hoc but undeclared). Update the README to install from it, document the test_api.py pytest suite, and drop references to the nonexistent bash auctions-curl version.